### PR TITLE
Fixed a fatal error that happens when trying to normalize an AddressM…

### DIFF
--- a/src/fields/AddressField.php
+++ b/src/fields/AddressField.php
@@ -273,6 +273,10 @@ class AddressField extends Field implements PreviewableFieldInterface
         // Convert raw data to an array
         $attr['raw'] = ($valid ? Json::decode($attr['raw']) : null);
 
+        if ($value instanceof AddressModel) {
+            $value = $value->distance;
+        }
+
         // If part of a proximity search, get the distance
         if ($value || is_numeric($value)) {
             $attr['distance'] = (float) $value;


### PR DESCRIPTION
This happens when Solspace Calendar is serializing an event to JSON and all the custom field values are being normalized.

Referencing issue #6