### PR TITLE
Add setting to override the Google API language

### DIFF
--- a/src/helpers/ApiHelper.php
+++ b/src/helpers/ApiHelper.php
@@ -12,6 +12,7 @@
 namespace doublesecretagency\googlemaps\helpers;
 
 use Craft;
+use craft\helpers\UrlHelper;
 use doublesecretagency\googlemaps\GoogleMapsPlugin;
 
 /**
@@ -95,22 +96,22 @@ class ApiHelper
      */
     public static function getApiUrl(array $params = []): string
     {
+        $baseParams = [];
+
         // Get browser key
-        $key = static::getBrowserKey();
+        $baseParams['key'] = static::getBrowserKey();
 
-        // Set base URL of Google Maps API
-        $googleMapsApi = 'https://maps.googleapis.com/maps/api/js';
-        $googleMapsApi .= "?key={$key}";
-
-        // Optionally append additional parameters
-        if ($params) {
-            foreach ($params as $param => $value) {
-                $googleMapsApi .= "&{$param}={$value}";
-            }
+        // Optionally append language parameters
+        $language = GoogleMapsPlugin::$plugin->getSettings()->language;
+        if ($language) {
+            $baseParams['language'] = $language;
         }
 
+        // Optionally append additional parameters
+        $params = array_merge($baseParams, $params);
+
         // Return complete API URL
-        return $googleMapsApi;
+        return UrlHelper::urlWithParams('https://maps.googleapis.com/maps/api/js', $params);
     }
 
 }

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -60,4 +60,9 @@ class Settings extends Model
      */
     public $enableJsLogging = true;
 
+    /**
+     * @var string|null Google API Language.
+     * @see https://developers.google.com/maps/documentation/javascript/localization
+     */
+    public $language;
 }


### PR DESCRIPTION
This allows to force a language that is used for the Google API calls. When the setting is not set, Google API continues using the browser language.

https://developers.google.com/maps/documentation/javascript/localization

Our use case for this setting is to get consistent lookup results in address fields for all users. Currently with Google Maps plugin we’re getting, for example, “Germany” for country address part when a user has the browser setup in English and “Deutschland” for users with a German browser.

In Smart Map we were always getting English results, because request were made from the server instead of the browser.