### PR TITLE
Add an ACF adapter for Google Map fields

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,9 @@
     "require": {
         "craftcms/cms": "^5.0.0"
     },
+    "require-dev": {
+        "craftcms/wp-import": "dev-main"
+    },
     "replace": {
         "doublesecretagency/craft-smartmap":"3.*"
     },

--- a/src/GoogleMapsPlugin.php
+++ b/src/GoogleMapsPlugin.php
@@ -28,6 +28,8 @@ use craft\services\Fields;
 use craft\services\Plugins;
 use craft\services\ProjectConfig;
 use craft\services\Utilities;
+use craft\wpimport\Command as WpImportCommand;
+use doublesecretagency\googlemaps\acfadapters\GoogleMap as GoogleMapAcfAdapter;
 use doublesecretagency\googlemaps\exporters\AddressesCondensedExporter;
 use doublesecretagency\googlemaps\exporters\AddressesExpandedExporter;
 use doublesecretagency\googlemaps\fields\AddressField;
@@ -100,6 +102,7 @@ class GoogleMapsPlugin extends Plugin
         $this->_registerFieldType();
         $this->_registerCompatibleFieldTypes();
         $this->_registerExporters();
+        $this->_registerAcfAdapter();
 
         // Manage conversions of the Address field
         $this->_manageFieldTypeConversions();
@@ -195,6 +198,26 @@ class GoogleMapsPlugin extends Plugin
             static function (RegisterElementExportersEvent $event) {
                 $event->exporters[] = AddressesCondensedExporter::class;
                 $event->exporters[] = AddressesExpandedExporter::class;
+            }
+        );
+    }
+
+    /**
+     * Register the ACF adapter for wp-import.
+     *
+     * @return void
+     */
+    private function _registerAcfAdapter(): void
+    {
+        if (!class_exists(WpImportCommand::class)) {
+            return;
+        }
+
+        Event::on(
+            WpImportCommand::class,
+            WpImportCommand::EVENT_REGISTER_ACF_ADAPTERS,
+            static function (RegisterComponentTypesEvent $event) {
+                $event->types[] = GoogleMapAcfAdapter::class;
             }
         );
     }

--- a/src/acfadapters/GoogleMap.php
+++ b/src/acfadapters/GoogleMap.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Google Maps plugin for Craft CMS
+ *
+ * Maps in minutes. Powered by the Google Maps API.
+ *
+ * @author    Double Secret Agency
+ * @author    Brandon Kelly
+ * @link      https://plugins.doublesecretagency.com/
+ * @copyright Copyright (c) 2014, 2024 Double Secret Agency
+ */
+
+namespace doublesecretagency\googlemaps\acfadapters;
+
+use craft\base\FieldInterface;
+use craft\wpimport\BaseAcfAdapter;
+use doublesecretagency\googlemaps\enums\Defaults;
+use doublesecretagency\googlemaps\fields\AddressField;
+
+/**
+ * Class GoogleMap
+ */
+class GoogleMap extends BaseAcfAdapter
+{
+    public static function type(): string
+    {
+        return 'google_map';
+    }
+
+    public function create(array $data): FieldInterface
+    {
+        $field = new AddressField();
+        $field->coordinatesDefault = [
+            'lat' => $data['center_lat'] ?: Defaults::COORDINATES['lat'],
+            'lng' => $data['center_lng'] ?: Defaults::COORDINATES['lng'],
+            'zoom' => $data['zoom'] ?: Defaults::COORDINATES['zoom'],
+        ];
+        return $field;
+    }
+
+    public function normalizeValue(mixed $value, array $data): mixed
+    {
+        return [
+            'lat' => $value['lat'],
+            'lng' => $value['lng'],
+            'zoom' => $value['zoom'],
+            'formatted' => $value['address'],
+            'name' => $value['name'],
+            'street1' => sprintf('%s %s', $value['street_number'], $value['street_name_short'] ?: $value['street_name']),
+            'city' => $value['city'],
+            'state' => $value['state_short'],
+            'zip' => $value['post_code'],
+            'country' => $value['country'],
+            'countryCode' => $value['country_short'],
+            'placeId' => $value['place_id'],
+        ];
+    }
+}


### PR DESCRIPTION
Registers an ACF adapter for a forthcoming WordPress → Craft import script.

We’ll be making the script public on Tuesday at 10am PT. If this is pulled in and tagged by then, we can mention it in the blog post :)