### PR TITLE
Craft cloud support

### DIFF
--- a/src/web/assets/AddressFieldAsset.php
+++ b/src/web/assets/AddressFieldAsset.php
@@ -43,8 +43,11 @@ class AddressFieldAsset extends AssetBundle
 
         $this->js = [
             'js/address.js',
-            $this->_getApiUrl(),
         ];
+
+        if (GoogleMapsPlugin::getInstance()) {
+            $this->js[] = $this->_getApiUrl();
+        }
     }
 
     /**

--- a/src/web/assets/AddressFieldSettingsAsset.php
+++ b/src/web/assets/AddressFieldSettingsAsset.php
@@ -14,6 +14,7 @@ namespace doublesecretagency\googlemaps\web\assets;
 use craft\web\AssetBundle;
 use craft\web\assets\cp\CpAsset;
 use craft\web\assets\vue\VueAsset;
+use doublesecretagency\googlemaps\GoogleMapsPlugin;
 use doublesecretagency\googlemaps\helpers\GoogleMaps;
 
 /**
@@ -43,12 +44,16 @@ class AddressFieldSettingsAsset extends AssetBundle
         $this->js = [
             'js/Sortable.min.js',
             'js/address-settings.js',
-            GoogleMaps::getApiUrl([
+        ];
+
+        if (GoogleMapsPlugin::getInstance()) {
+            $this->js[] = GoogleMaps::getApiUrl([
                 'loading' => 'async',
                 'libraries' => 'places',
                 'callback' => 'initAddressFieldSettings',
-            ]),
-        ];
+            ]);
+        }
+
     }
 
 }

--- a/src/web/assets/GoogleMapsAsset.php
+++ b/src/web/assets/GoogleMapsAsset.php
@@ -28,6 +28,10 @@ class GoogleMapsAsset extends AssetBundle
     {
         parent::init();
 
+        if (!GoogleMapsPlugin::getInstance()) {
+            return;
+        }
+
         // Load Google Maps API
         $this->js = [
             GoogleMaps::getApiUrl()

--- a/src/web/assets/JsApiAsset.php
+++ b/src/web/assets/JsApiAsset.php
@@ -34,7 +34,7 @@ class JsApiAsset extends AssetBundle
         ];
 
         // Whether to use minified JavaScript files
-        $minifyJsFiles = (GoogleMapsPlugin::$plugin->getSettings()->minifyJsFiles ?? false);
+        $minifyJsFiles = (GoogleMapsPlugin::getInstance()?->getSettings()->minifyJsFiles ?? false);
 
         // Optionally use minified files
         $min = ($minifyJsFiles ? 'min.' : '');


### PR DESCRIPTION
See https://craftcms.com/knowledge-base/cloud-plugin-development#asset-bundles

Your Asset Bundles are assuming the plugin is instantiated (and thus Craft is installed), when nothing is actually enforcing that.

Technically, your use of `\doublesecretagency\googlemaps\GoogleMapsPlugin::$plugin` is mis-typed, as it can be `null` when Craft isn't installed, which happens to be the case when Craft Clouds is running `craft cloud/build` to send asset bundle resources to the CDN.

Ideally you should use the existing `\yii\base\Module::getInstance`, which is appropriately typed as `null|Module`, which would have made this more obvious.